### PR TITLE
Add carousel thumbnail previews

### DIFF
--- a/app/[lang]/vehicle/[vehicleId]/page.tsx
+++ b/app/[lang]/vehicle/[vehicleId]/page.tsx
@@ -8,7 +8,8 @@ import { vehiclesData } from "@/lib/vehicles"
 import type { Vehicle, Locale } from "@/lib/types"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel"
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, type CarouselApi } from "@/components/ui/carousel"
+import { cn } from "@/lib/utils"
 import { ArrowLeft, Users, Zap, Tag, CheckCircle } from "lucide-react"
 import { useI18n, I18nProvider } from "@/context/i18n-context"
 import ReservationForm from "@/components/reservation-form"
@@ -20,6 +21,18 @@ const VehicleDetailContent = ({ lang }: { lang: Locale }) => {
   const router = useRouter()
   const [vehicle, setVehicle] = useState<Vehicle | null>(null)
   const [showReservationForm, setShowReservationForm] = useState(false)
+  const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  useEffect(() => {
+    if (!carouselApi) return
+    const handler = () => setSelectedIndex(carouselApi.selectedScrollSnap())
+    carouselApi.on("select", handler)
+    handler()
+    return () => {
+      carouselApi.off("select", handler)
+    }
+  }, [carouselApi])
 
   useEffect(() => {
     const vehicleId = params.vehicleId as string
@@ -73,7 +86,7 @@ const VehicleDetailContent = ({ lang }: { lang: Locale }) => {
             <div className="bg-card rounded-2xl p-6 border border-gray-800">
               <h3 className="text-xl font-semibold mb-4 text-kadoshGreen-DEFAULT">{t("gallery", "vehicleDetails")}</h3>
               {vehicle.images.length > 0 ? (
-                <Carousel className="w-full">
+                <Carousel className="w-full" setApi={setCarouselApi}>
                   <CarouselContent>
                     {vehicle.images.map((src, index) => (
                       <CarouselItem key={index}>
@@ -95,6 +108,22 @@ const VehicleDetailContent = ({ lang }: { lang: Locale }) => {
                     </>
                   )}
                 </Carousel>
+                {vehicle.images.length > 1 && (
+                  <div className="mt-4 flex justify-center gap-3 overflow-x-auto">
+                    {vehicle.images.map((src, idx) => (
+                      <button
+                        key={idx}
+                        onClick={() => carouselApi?.scrollTo(idx)}
+                        className={cn(
+                          "relative h-16 w-24 rounded overflow-hidden border-2",
+                          idx === selectedIndex ? "border-kadoshGreen-DEFAULT" : "border-transparent"
+                        )}
+                      >
+                        <Image src={src} alt={`thumb ${idx + 1}`} fill className="object-cover" />
+                      </button>
+                    ))}
+                  </div>
+                )}
               ) : (
                 <div className="w-full h-80 bg-gray-800 rounded-xl flex items-center justify-center">
                   <p className="text-gray-500">{t("noVehicles", "vehicleCatalog")}</p>

--- a/components/vehicle-detail-modal.tsx
+++ b/components/vehicle-detail-modal.tsx
@@ -1,6 +1,8 @@
 "use client"
 import Image from "next/image"
 import type { Vehicle } from "@/lib/types"
+import { useState, useEffect } from "react"
+import { cn } from "@/lib/utils"
 import {
   Dialog,
   DialogContent,
@@ -11,7 +13,7 @@ import {
   DialogClose,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel"
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, type CarouselApi } from "@/components/ui/carousel"
 import { Users, Zap, Info, CheckCircle } from "lucide-react"
 import { useI18n } from "@/context/i18n-context"
 
@@ -24,6 +26,18 @@ interface VehicleDetailModalProps {
 
 export default function VehicleDetailModal({ vehicle, isOpen, onClose, onReserveClick }: VehicleDetailModalProps) {
   const { t } = useI18n()
+  const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  useEffect(() => {
+    if (!carouselApi) return
+    const handler = () => setSelectedIndex(carouselApi.selectedScrollSnap())
+    carouselApi.on("select", handler)
+    handler()
+    return () => {
+      carouselApi.off("select", handler)
+    }
+  }, [carouselApi])
 
   if (!vehicle) return null
 
@@ -39,7 +53,7 @@ export default function VehicleDetailModal({ vehicle, isOpen, onClose, onReserve
           <div>
             <h3 className="text-lg font-semibold mb-2 text-kadoshGreen-DEFAULT">{t("gallery", "vehicleDetails")}</h3>
             {vehicle.images.length > 0 ? (
-              <Carousel className="w-full">
+              <Carousel className="w-full" setApi={setCarouselApi}>
                 <CarouselContent>
                   {vehicle.images.map((src, index) => (
                     <CarouselItem key={index}>
@@ -61,6 +75,24 @@ export default function VehicleDetailModal({ vehicle, isOpen, onClose, onReserve
                   </>
                 )}
               </Carousel>
+              {vehicle.images.length > 1 && (
+                <div className="mt-3 flex justify-center gap-2 overflow-x-auto">
+                  {vehicle.images.map((src, idx) => (
+                    <button
+                      key={idx}
+                      onClick={() => carouselApi?.scrollTo(idx)}
+                      className={cn(
+                        "relative h-12 w-20 rounded overflow-hidden border-2",
+                        idx === selectedIndex
+                          ? "border-kadoshGreen-DEFAULT"
+                          : "border-transparent"
+                      )}
+                    >
+                      <Image src={src} alt={`thumb ${idx + 1}`} fill className="object-cover" />
+                    </button>
+                  ))}
+                </div>
+              )}
             ) : (
               <p className="text-muted-foreground">{t("noImages", "vehicleDetails")}</p>
             )}


### PR DESCRIPTION
## Summary
- improve VehicleDetail page and modal with a row of thumbnails below the carousel so users know which image they're on
- track active slide to highlight the current thumbnail

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_685b042fe500832883b77946325f18ea