### PR TITLE
Add slider-based price filter and seats dropdown

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -30,7 +30,10 @@ const PageContent = ({ lang }: { lang: Locale }) => {
     priceLimits.max,
   ])
   const seatOptions = useMemo(
-    () => Array.from(new Set(vehiclesData.map((v) => v.seats))).sort(),
+    () =>
+      Array.from(new Set(vehiclesData.map((v) => v.seats))).sort(
+        (a, b) => a - b
+      ),
     []
   )
   const [minSeats, setMinSeats] = useState<number | "">("")

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -6,6 +6,7 @@ import type { Vehicle, Locale } from "@/lib/types"
 import VehicleCard from "@/components/vehicle-card"
 import ReservationModal from "@/components/reservation-modal"
 import { Input } from "@/components/ui/input"
+import { Slider } from "@/components/ui/slider"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { Search, Filter, XCircle, Star, Clock, MapPin, CreditCard } from "lucide-react"
@@ -17,6 +18,22 @@ const PageContent = ({ lang }: { lang: Locale }) => {
   const [filteredVehicles, setFilteredVehicles] = useState<Vehicle[]>(vehiclesData)
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedCategory, setSelectedCategory] = useState<string>("all")
+  const priceLimits = useMemo(() => {
+    const prices = vehiclesData.map((v) => v.pricePerDay)
+    return {
+      min: Math.min(...prices),
+      max: Math.max(...prices),
+    }
+  }, [])
+  const [priceRange, setPriceRange] = useState<[number, number]>([
+    priceLimits.min,
+    priceLimits.max,
+  ])
+  const seatOptions = useMemo(
+    () => Array.from(new Set(vehiclesData.map((v) => v.seats))).sort(),
+    []
+  )
+  const [minSeats, setMinSeats] = useState<number | "">("")
   const [selectedVehicleForReservation, setSelectedVehicleForReservation] = useState<Vehicle | null>(null)
   const [isReservationModalOpen, setIsReservationModalOpen] = useState(false)
 
@@ -33,8 +50,14 @@ const PageContent = ({ lang }: { lang: Locale }) => {
     if (selectedCategory !== "all") {
       vehicles = vehicles.filter((v) => v.category === selectedCategory)
     }
+    vehicles = vehicles.filter(
+      (v) => v.pricePerDay >= priceRange[0] && v.pricePerDay <= priceRange[1]
+    )
+    if (minSeats !== "") {
+      vehicles = vehicles.filter((v) => v.seats >= Number(minSeats))
+    }
     setFilteredVehicles(vehicles)
-  }, [searchTerm, selectedCategory])
+  }, [searchTerm, selectedCategory, priceRange, minSeats])
 
   const handleReserveClick = (vehicle: Vehicle) => {
     setSelectedVehicleForReservation(vehicle)
@@ -119,7 +142,7 @@ const PageContent = ({ lang }: { lang: Locale }) => {
             {/* Filters */}
             <div className="mb-12 p-8 bg-card rounded-2xl shadow-2xl border border-gray-800">
               <h3 className="text-xl font-semibold text-kadoshGreen-DEFAULT mb-6">{t("filters", "vehicleCatalog")}</h3>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-end">
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-6 items-end">
                 <div>
                   <label htmlFor="search" className="block text-sm font-semibold text-kadoshGreen-DEFAULT mb-3">
                     <Search size={16} className="inline mr-2" />
@@ -133,6 +156,48 @@ const PageContent = ({ lang }: { lang: Locale }) => {
                     onChange={(e) => setSearchTerm(e.target.value)}
                     className="bg-input border-gray-700 focus:border-kadoshGreen-DEFAULT h-12 text-lg"
                   />
+                </div>
+
+                <div className="md:col-span-2">
+                  <label className="block text-sm font-semibold text-kadoshGreen-DEFAULT mb-3">
+                    {t("priceRange", "vehicleCatalog")}
+                  </label>
+                  <Slider
+                    value={priceRange}
+                    min={priceLimits.min}
+                    max={priceLimits.max}
+                    step={5}
+                    onValueChange={(val) => setPriceRange(val as [number, number])}
+                    className="w-full"
+                  />
+                  <div className="flex justify-between text-sm text-gray-400 mt-2">
+                    <span>${priceRange[0]}</span>
+                    <span>${priceRange[1]}</span>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-semibold text-kadoshGreen-DEFAULT mb-3">
+                    {t("seats", "vehicleCatalog")}
+                  </label>
+                  <Select
+                    value={minSeats === "" ? "" : String(minSeats)}
+                    onValueChange={(v) =>
+                      setMinSeats(v === "" ? "" : Number(v))
+                    }
+                  >
+                    <SelectTrigger className="w-full bg-input border-gray-700 focus:border-kadoshGreen-DEFAULT h-12 text-lg">
+                      <SelectValue placeholder="Any" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-card border-kadoshGreen-DEFAULT">
+                      <SelectItem value="">Any</SelectItem>
+                      {seatOptions.map((seat) => (
+                        <SelectItem key={seat} value={String(seat)}>
+                          {seat}+
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
 
                 <div>
@@ -160,6 +225,8 @@ const PageContent = ({ lang }: { lang: Locale }) => {
                     onClick={() => {
                       setSearchTerm("")
                       setSelectedCategory("all")
+                      setPriceRange([priceLimits.min, priceLimits.max])
+                      setMinSeats("")
                     }}
                     variant="outline"
                     className="w-full border-kadoshGreen-DEFAULT text-kadoshGreen-DEFAULT hover:bg-kadoshGreen-DEFAULT hover:text-kadoshBlack-DEFAULT h-12 text-lg font-semibold"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,6 +67,8 @@ export type Translations = {
     tryDifferentFilters: string
     searchPlaceholder: string
     filters: string
+    priceRange: string
+    seats: string
   }
   reservationForm: {
     title: string

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -57,6 +57,8 @@ const en: Translations = {
     tryDifferentFilters: "Try adjusting your filters",
     searchPlaceholder: "Search vehicles...",
     filters: "Filters",
+    priceRange: "Price Range",
+    seats: "Seats",
   },
   reservationForm: {
     title: "Make a Reservation",

--- a/locales/es.ts
+++ b/locales/es.ts
@@ -57,6 +57,8 @@ const es: Translations = {
     tryDifferentFilters: "Intenta ajustar tus filtros",
     searchPlaceholder: "Buscar vehículos...",
     filters: "Filtros",
+    priceRange: "Rango de Precios",
+    seats: "Asientos",
   },
   reservationForm: {
     title: "Hacer una Reserva",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -57,6 +57,8 @@ const fr: Translations = {
     tryDifferentFilters: "Essayez d'ajuster vos filtres",
     searchPlaceholder: "Rechercher véhicules...",
     filters: "Filtres",
+    priceRange: "Fourchette de Prix",
+    seats: "Sièges",
   },
   reservationForm: {
     title: "Faire une Réservation",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
-    "next-env.d.ts"
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- implement price range slider and seats dropdown in catalog filters
- update translation types and locale strings for new labels
- include Next.js type definitions in `tsconfig`

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c0f08681c83288008ef614f3691c0