### PR TITLE
Add slider-based price filter and seats dropdown

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,6 +67,9 @@ export type Translations = {
     tryDifferentFilters: string
     searchPlaceholder: string
     filters: string
+    priceRange: string
+    seats: string
+    featuresFilter: string
   }
   reservationForm: {
     title: string

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -57,6 +57,9 @@ const en: Translations = {
     tryDifferentFilters: "Try adjusting your filters",
     searchPlaceholder: "Search vehicles...",
     filters: "Filters",
+    priceRange: "Price Range",
+    seats: "Seats",
+    featuresFilter: "Features",
   },
   reservationForm: {
     title: "Make a Reservation",

--- a/locales/es.ts
+++ b/locales/es.ts
@@ -57,6 +57,9 @@ const es: Translations = {
     tryDifferentFilters: "Intenta ajustar tus filtros",
     searchPlaceholder: "Buscar vehículos...",
     filters: "Filtros",
+    priceRange: "Rango de Precios",
+    seats: "Asientos",
+    featuresFilter: "Características",
   },
   reservationForm: {
     title: "Hacer una Reserva",

--- a/locales/fr.ts
+++ b/locales/fr.ts
@@ -57,6 +57,9 @@ const fr: Translations = {
     tryDifferentFilters: "Essayez d'ajuster vos filtres",
     searchPlaceholder: "Rechercher véhicules...",
     filters: "Filtres",
+    priceRange: "Fourchette de Prix",
+    seats: "Sièges",
+    featuresFilter: "Caractéristiques",
   },
   reservationForm: {
     title: "Faire une Réservation",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
-    "next-env.d.ts"
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- implement price range slider and seats dropdown in catalog filters
- expand localization types and strings for new filters
- include Next.js type definitions
- sort seat options numerically
- add features checkbox filter

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685c0f08681c83288008ef614f3691c0